### PR TITLE
Added 'All' in Per Page select box options

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ pagination: {
   container_class: '.users-pagination',  //Add pagination div class. Default  is .st_pagination.
   ul_class: '.larger-pagination',        //Add pagination ul class. Default is  .pagination.
   per_page_select: true,                 //Show per page select box. Default us true.
-  per_page_opts: [10, 25, 50],           //Per Page select box options. Default is [10, 25, 50].
+  per_page_opts: [[10, 25, 50,-1],[10,25,50,"All"],          //Per Page select box options. Default is [[10, 25, 50, -1],[10,25,50,"All"].
   per_page_class: '.select-box'          //Per page select box class. Default is .st_per_page.
   per_page: 20                           //Show number of record per page. Defalut 10.
 }
@@ -240,7 +240,7 @@ var options = {
 		container_class: '.users-pagination', 
 		ul_class: '.larger-pagination',       
 		per_page_select: true,                 
-		per_page_opts: [10,25,50],            
+		per_page_opts: [[10, 25, 50,-1],[10,25,50,"All"],
 		per_page_class: '.select-box',       
 		per_page: 20      
 	},

--- a/stream_table.js
+++ b/stream_table.js
@@ -89,7 +89,7 @@
       prev_text: '&laquo;',
       next_text: '&laquo;',
       per_page_select: true,
-      per_page_opts: [10,25,50]
+      per_page_opts: [[10,25,50,-1],[10,25,50,"All"]]
     }, opts);
 
     var p_classes = ['st_pagination'];
@@ -98,7 +98,7 @@
       p_classes = [].concat.apply(p_classes, [opts.container_class]);
     }
 
-    this.paging_opts.per_page = this.paging_opts.per_page_opts[0] || 10;
+    this.paging_opts.per_page = this.paging_opts.per_page_opts[0][0] || 10;
     this.paging_opts.container_class = p_classes.join(' ');
     this.paging_opts.ul_class = ['pagination', opts.ul_class].join(' ');
     this.paging_opts.per_page_class = ['st_per_page', opts.per_page_class].join(' ');
@@ -207,6 +207,9 @@
         index,
         d = this.has_sorting ? this.getIndex() : this.getData();
 
+        if(l == -1){
+          l = d.length;
+        }
     if (d.length < l) l = d.length;
 
     if (this.has_sorting){
@@ -418,8 +421,8 @@
     html = ['<select size="1" name="per_page" class="'+ this.paging_opts.per_page_class +'">'];
     arr = this.paging_opts.per_page_opts;
 
-    for(var i = 0, l = arr.length; i < l; i ++)
-        html.push('<option value="'+ arr[i] + '">'+ arr[i] +'</option>');
+    for(var i = 0, l = arr[0].length; i < l; i ++)
+        html.push('<option value="'+ arr[0][i] + '">'+ arr[1][i] +'</option>');
 
     html.push('</select>');
     $(this.main_container).before(html.join(''));


### PR DESCRIPTION
Problems:-

1. If a user wants to show "All data on a single page then he can't show because in the pagination select box there is no option to show "All" data on a single page.
2. When a user searches a specific word into data then searched results are showed on multiple pages depending on per_page size, when user checking searched results are correct or not. then he should go to every page and check results.

Proposed Solution:-
 

1. I have added a two-dimensional array in paging_opts object, Like
         **per_page_opts: [[10,25,50,-1],[10,25,50,"All"]]**
    - the per_page_otps[0] used for select option value - [10,25,50,-1],
    -per_page_otps[1] userd for select option name - [10,25,50,"All"]
so when user select 'All' from select box then **paging_opts.per_page** value will be  **-1**.
2. In render function I have added one condtion to check page value is -1 or not , if **yes** then I am setting
   l = data.length
to render all data on a single page.
this is how the proposed code will solve the above problem